### PR TITLE
Pillar motion Neural Network

### DIFF
--- a/configs/_base_/models/motionnet_02pillar_stpn_nus.py
+++ b/configs/_base_/models/motionnet_02pillar_stpn_nus.py
@@ -1,9 +1,9 @@
-number_past_scans = 10
+number_past_scans = 5
 voxel_size = [0.2, 0.2, 8]
 model = dict(
     type='MotionNet',
     pts_voxel_layer=dict(
-        max_num_points=20, voxel_size=voxel_size, max_voxels=(30000, 40000)),
+        max_num_points=20, voxel_size=voxel_size, nsweeps=number_past_scans, max_voxels=30000), #max_voxels=(30000, 40000)
     pts_voxel_encoder=dict(
         type='PillarFeatureNet',
         in_channels=5,
@@ -24,7 +24,7 @@ model = dict(
     #     conv_cfg=dict(type='Conv2d', bias=False)),
     pts_neck=dict(
         type='STPN',
-        height_feat_size=13
+        height_feat_size=64
         #type='SECONDFPN',
         # in_channels=[64, 128, 256],
         # out_channels=[128, 128, 128],
@@ -62,7 +62,7 @@ model = dict(
     #     norm_bbox=True),
     motion_prediction_head=dict(
         type='MotionPrediction',
-        seq_len=10
+        seq_len=number_past_scans
     ),
     # model training and testing settings
     train_cfg=dict(

--- a/configs/motionnet/motionnet_02pillar_stpn_cyclic_nus.py
+++ b/configs/motionnet/motionnet_02pillar_stpn_cyclic_nus.py
@@ -28,7 +28,7 @@ file_client_args = dict(backend='disk')
 
 db_sampler = dict(
     data_root=data_root,
-    info_path=data_root + 'nuscenes_dbinfos_train.pkl',
+    info_path=data_root + 'nus_5_sweeps_dbinfos_train.pkl',
     rate=1.0,
     prepare=dict(
         filter_by_difficulty=[-1],
@@ -77,7 +77,7 @@ train_pipeline = [
         pad_empty_sweeps=True,
         remove_close=True),
     dict(type='LoadAnnotations3D', with_bbox_3d=True, with_label_3d=True),
-    dict(type='ObjectSample', db_sampler=db_sampler),
+    # dict(type='ObjectSample', db_sampler=db_sampler),
     dict(
         type='GlobalRotScaleTrans',
         rot_range=[-0.3925, 0.3925],
@@ -94,6 +94,7 @@ train_pipeline = [
     dict(type='PointShuffle'),
     dict(type='DefaultFormatBundle3D', class_names=class_names),
     dict(type='Collect3D', keys=['points', 'gt_bboxes_3d', 'gt_labels_3d'])
+    # dict(type='Collect3D', keys=['points'])
 ]
 test_pipeline = [
     dict(
@@ -157,7 +158,7 @@ data = dict(
         dataset=dict(
             type=dataset_type,
             data_root=data_root,
-            ann_file=data_root + 'nuscenes_infos_train.pkl',
+            ann_file=data_root + 'motion_mini/nus_5_sweeps_infos_train.pkl',
             pipeline=train_pipeline,
             classes=class_names,
             test_mode=False,

--- a/mmdet3d/core/voxel/voxel_generator.py
+++ b/mmdet3d/core/voxel/voxel_generator.py
@@ -200,7 +200,7 @@ def _points_to_voxel_reverse_kernel(points,
                 failed = True
                 break
             coor[ndim_minus_1 - j] = c  # zyx
-            # this is probably incorrect. this will cause all sweeps to have 0th
+            # TODO: this is probably incorrect. this will cause all sweeps to have 0th
             # dim for time diff. 
             coor[3] = int(points[i, -1]) 
         if failed:

--- a/mmdet3d/models/decode_heads/motion_prediction_head.py
+++ b/mmdet3d/models/decode_heads/motion_prediction_head.py
@@ -18,12 +18,13 @@ class MotionPrediction(nn.Module):
     def __init__(self, seq_len):
         super(MotionPrediction, self).__init__()
         self.conv1 = nn.Conv2d(32, 32, kernel_size=3, stride=1, padding=1)
-        self.conv2 = nn.Conv2d(32, 2 * seq_len, kernel_size=1, stride=1, padding=0)
+        # self.conv2 = nn.Conv2d(32, 2 * seq_len, kernel_size=1, stride=1, padding=0) #MotionNet
+        self.conv2 = nn.Conv2d(32, 2, kernel_size=1, stride=1, padding=0)   #Pillar Motion
 
         self.bn1 = nn.BatchNorm2d(32)
 
     def forward(self, x):
         x = F.relu(self.bn1(self.conv1(x)))
         x = self.conv2(x)
-
+        x = x.permute(0, 2, 3, 1).contiguous()
         return x

--- a/mmdet3d/models/detectors/motionnet.py
+++ b/mmdet3d/models/detectors/motionnet.py
@@ -110,10 +110,10 @@ class MotionNet(MVXTwoStageDetector):
         """
         voxels, coors, num_points = [], [], []
         for res in points:
-            res_voxels, res_coors, res_num_points = self.pts_voxel_layer.generate(res)
-            voxels.append(res_voxels)
-            coors.append(res_coors)
-            num_points.append(res_num_points)
+            res_voxels, res_coors, res_num_points = self.pts_voxel_layer.generate(res.cpu().numpy())
+            voxels.append(torch.from_numpy(res_voxels).to(res.device))
+            coors.append(torch.from_numpy(res_coors).to(res.device))
+            num_points.append(torch.from_numpy(res_num_points).to(res.device))
         voxels = torch.cat(voxels, dim=0)
         num_points = torch.cat(num_points, dim=0)
         coors_batch = []

--- a/mmdet3d/models/detectors/motionnet.py
+++ b/mmdet3d/models/detectors/motionnet.py
@@ -7,6 +7,7 @@ from .mvx_two_stage import MVXTwoStageDetector
 from .. import builder
 from mmdet3d.core import VoxelGenerator
 from mmcv.runner import force_fp32
+from torch.nn import functional as F
 
 """
 The below code is credited from the paper
@@ -50,7 +51,7 @@ class MotionNet(MVXTwoStageDetector):
                              train_cfg, test_cfg, pretrained, init_cfg)
 
         if motion_prediction_head is not None:
-            self.motion_pred = builder.build_head(motion_prediction_head)
+            self.motion_pred_head = builder.build_head(motion_prediction_head)
 
         # override pts_voxel_layer
         self.pts_voxel_layer = VoxelGenerator(**pts_voxel_layer_copy)
@@ -159,7 +160,8 @@ class MotionNet(MVXTwoStageDetector):
         Returns:
             dict: Losses of each branch.
         """
-        outs = self.pts_bbox_head(pts_feats)
+        outs = self.motion_pred_head(pts_feats)
+        # outs = self.pts_bbox_head(pts_feats)
         loss_inputs = [gt_bboxes_3d, gt_labels_3d, outs]
         losses = self.pts_bbox_head.loss(*loss_inputs)
         return losses

--- a/mmdet3d/models/middle_encoders/pillar_scatter_temporal.py
+++ b/mmdet3d/models/middle_encoders/pillar_scatter_temporal.py
@@ -1,0 +1,102 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+from mmcv.runner import auto_fp16
+from torch import nn
+
+from ..builder import MIDDLE_ENCODERS
+
+
+@MIDDLE_ENCODERS.register_module()
+class PointPillarsScatter(nn.Module):
+    """Point Pillar's Scatter.
+
+    Converts learned features from dense tensor to sparse pseudo image.
+
+    Args:
+        in_channels (int): Channels of input features.
+        output_shape (list[int]): Required output shape of features.
+    """
+
+    def __init__(self, in_channels, output_shape):
+        super().__init__()
+        self.output_shape = output_shape
+        self.ny = output_shape[0]
+        self.nx = output_shape[1]
+        self.in_channels = in_channels
+        self.fp16_enabled = False
+
+    @auto_fp16(apply_to=('voxel_features', ))
+    def forward(self, voxel_features, coors, batch_size=None):
+        """Foraward function to scatter features."""
+        # TODO: rewrite the function in a batch manner
+        # no need to deal with different batch cases
+        if batch_size is not None:
+            return self.forward_batch(voxel_features, coors, batch_size)
+        else:
+            return self.forward_single(voxel_features, coors)
+
+    def forward_single(self, voxel_features, coors):
+        """Scatter features of single sample.
+
+        Args:
+            voxel_features (torch.Tensor): Voxel features in shape (N, M, C).
+            coors (torch.Tensor): Coordinates of each voxel.
+                The first column indicates the sample ID.
+        """
+        # Create the canvas for this sample
+        canvas = torch.zeros(
+            self.in_channels,
+            self.nx * self.ny,
+            dtype=voxel_features.dtype,
+            device=voxel_features.device)
+
+        indices = coors[:, 1] * self.nx + coors[:, 2]
+        indices = indices.long()
+        voxels = voxel_features.t()
+        # Now scatter the blob back to the canvas.
+        canvas[:, indices] = voxels
+        # Undo the column stacking to final 4-dim tensor
+        canvas = canvas.view(1, self.in_channels, self.ny, self.nx)
+        return [canvas]
+
+    def forward_batch(self, voxel_features, coors, batch_size):
+        """Scatter features of single sample.
+
+        Args:
+            voxel_features (torch.Tensor): Voxel features in shape (N, M, C).
+            coors (torch.Tensor): Coordinates of each voxel in shape (N, 4).
+                The first column indicates the sample ID.
+            batch_size (int): Number of samples in the current batch.
+        """
+        # batch_canvas will be the final output.
+        batch_canvas = []
+        for batch_itt in range(batch_size):
+            # Create the canvas for this sample
+            canvas = torch.zeros(
+                self.in_channels,
+                self.nx * self.ny,
+                dtype=voxel_features.dtype,
+                device=voxel_features.device)
+
+            # Only include non-empty pillars
+            batch_mask = coors[:, 0] == batch_itt
+            this_coors = coors[batch_mask, :]
+            indices = this_coors[:, 2] * self.nx + this_coors[:, 3]
+            indices = indices.type(torch.long)
+            voxels = voxel_features[batch_mask, :]
+            voxels = voxels.t()
+
+            # Now scatter the blob back to the canvas.
+            canvas[:, indices] = voxels
+
+            # Append to a list for later stacking.
+            batch_canvas.append(canvas)
+
+        # Stack to 3-dim tensor (batch-size, in_channels, nrows*ncols)
+        batch_canvas = torch.stack(batch_canvas, 0)
+
+        # Undo the column stacking to final 4-dim tensor
+        batch_canvas = batch_canvas.view(batch_size, self.in_channels, self.ny,
+                                         self.nx)
+
+        return batch_canvas


### PR DESCRIPTION
## Motivation
First Neural Net design of MotionNet

## Modification
- Added a base model configuration for MotionNet (see `configs/_base_/models/motionnet_02pillar_stpn_nus.py`) 
- Added a training configuration for MotionNet (see `configs/motionnet/motionnet_02pillar_stpn_cyclic_nus.py`)
- Added a middle encoder for incorporating temporal information (see `mmdet3d/models/middle_encoders/pillar_scatter_temporal.py`) 
- Modified motion prediction head to output correcly 

## BC-breaking (Optional)
- Modified VoxelGenerator to extend canvas along temporal dimension (see ` mmdet3d/core/voxel/voxel_generator.py`)
 
## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.

TODO later